### PR TITLE
make CLI use the library

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,8 @@
 use anyhow::Error;
 use clap::Parser;
 
-mod config;
-mod middleware;
-#[cfg(test)]
-mod testutils;
-mod types;
-
-use middleware::{server::Server, Upstream};
+use statsdproxy::config;
+use statsdproxy::middleware::{server::Server, Upstream, self};
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use anyhow::Error;
 use clap::Parser;
 
 use statsdproxy::config;
-use statsdproxy::middleware::{server::Server, Upstream, self};
+use statsdproxy::middleware::{self, server::Server, Upstream};
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]


### PR DESCRIPTION
currently, if I run cargo test, all the tests run twice.

this is because all the sourcecode is directly included into main using
`mod`, and then separately for the library.

instead, the CLI should use the library as the dependency.

this is also better for compilation caches.
