### PR TITLE
fix(cadence): Avoid mutex around inner middleware

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,4 +38,4 @@ jobs:
       - uses: actions/checkout@v3
         name: Checkout code
       - name: Run tests
-        run: cargo build --no-default-features --lib --features cadence
+        run: cargo build --no-default-features --lib --features cadence-adapter

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,6 +474,7 @@ dependencies = [
  "serde",
  "serde_yaml",
  "signal-hook",
+ "thread_local",
 ]
 
 [[package]]
@@ -500,6 +501,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+dependencies = [
+ "cfg-if",
+ "once_cell",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,12 +19,15 @@ serde_yaml = { version = "0.9", optional = true }
 cadence = { version = "0.29.0", optional = true }
 log = "0.4"
 signal-hook = { version = "0.3.17", optional = true }
+thread_local = { version = "1.1.7", optional = true }
 
 [features]
 default = ["cli"]
 # opt out of cli feature to get rid of CLI dependencies
 cli = ["clap", "serde", "serde_yaml", "signal-hook"]
+
 # opt into cadence feature to enable cadence adapter
+cadence-adapter = ["cadence", "thread_local"]
 
 [dev-dependencies]
 insta = { version = "1.31.0", features = ["yaml"] }

--- a/src/middleware/aggregate.rs
+++ b/src/middleware/aggregate.rs
@@ -138,6 +138,7 @@ where
         #[cfg(not(test))]
         let overwrite_now = None;
 
+        #[allow(clippy::unnecessary_literal_unwrap)]
         let now = overwrite_now.unwrap_or_else(|| {
             SystemTime::now()
                 .duration_since(UNIX_EPOCH)


### PR DESCRIPTION
A few months ago we attempted to roll this out for rust_snuba, and found
significant performance overhead. We don't actually know whether this is
the bottleneck but it seems likely. Single-thread performance in
synthetic benchmarks looks to be about the same.
