### PR TITLE
fix: Make types public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,4 +4,4 @@ pub mod config;
 pub mod middleware;
 
 mod testutils;
-mod types;
+pub mod types;


### PR DESCRIPTION
middleware is also public, and we need the Metric type to be public
