### PR TITLE
meta: Bump package version in Cargo.lock on release

### DIFF
--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -14,3 +14,4 @@ function replace() {
 }
 
 replace "^version = \".*?\"" "version = \"$NEW_VERSION\"" Cargo.toml
+cargo update -p statsdproxy


### PR DESCRIPTION
The release process updates the version number in the Cargo.toml file but doesn't apply this to the Cargo.lock. The next time the repository is pulled and built, the version number will mismatch. 

This adds an update command to ensure the lockfile is up-to-date before publishing.