### PR TITLE
fix: resolve clippy warnings for newer Rust versions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,5 +3,6 @@ pub mod cadence;
 pub mod config;
 pub mod middleware;
 
+#[cfg(test)]
 mod testutils;
 pub mod types;

--- a/src/types.rs
+++ b/src/types.rs
@@ -40,7 +40,7 @@ pub struct MetricTag<'a> {
 }
 
 impl MetricTag<'_> {
-    pub fn new(bytes: &[u8]) -> MetricTag {
+    pub fn new(bytes: &[u8]) -> MetricTag<'_> {
         MetricTag {
             raw: bytes,
             name_value_sep_pos: bytes.iter().position(|&b| b == b':'),
@@ -135,7 +135,7 @@ impl Metric {
         self.tags_pos.map(|(i, j)| &self.raw[i..j])
     }
 
-    pub fn tags_iter(&self) -> MetricTagIterator {
+    pub fn tags_iter(&self) -> MetricTagIterator<'_> {
         MetricTagIterator {
             remaining_tags: self.tags(),
         }


### PR DESCRIPTION
## Summary
- Mark `testutils` module as `#[cfg(test)]` to fix `dead_code` warning for `FnStep` struct
- Add explicit `'_` lifetime annotations to `MetricTag::new` and `Metric::tags_iter` to satisfy the `mismatched_lifetime_syntaxes` lint

These warnings are triggered by newer Rust/clippy versions and are currently blocking CI on open PRs (#61, #63).

## Test plan
- [x] `make lint` passes locally
- [x] `make test` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)